### PR TITLE
require statements no longer work with latest minitest-rails gem

### DIFF
--- a/lib/minitest/rails/shoulda/matchers.rb
+++ b/lib/minitest/rails/shoulda/matchers.rb
@@ -1,7 +1,7 @@
 require "minitest/matchers"
+require "minitest/rails"
 
 if defined?(ActiveRecord)
-  require "minitest/rails/active_support"
   require "shoulda/matchers/active_record"
 
   Shoulda::Matchers::ActiveRecord.module_eval do
@@ -18,7 +18,6 @@ if defined?(ActiveRecord)
 end
 
 if defined?(ActiveModel)
-  require "minitest/rails/active_support"
   require "shoulda/matchers/active_model"
 
   Shoulda::Matchers::ActiveModel.module_eval do
@@ -35,7 +34,6 @@ if defined?(ActiveModel)
 end
 
 if defined?(ActionController)
-  require "minitest/rails/action_controller"
   require "shoulda/matchers/action_controller"
 
   Shoulda::Matchers::ActionController.module_eval do
@@ -52,7 +50,6 @@ if defined?(ActionController)
 end
 
 if defined?(ActionMailer)
-  require "minitest/rails/action_mailer"
   require "shoulda/matchers/action_mailer"
 
   Shoulda::Matchers::ActionMailer.module_eval do


### PR DESCRIPTION
Within /lib/minitest/rails/shouldamatchers.rb there are a series of **require "minitest/rails/rails_libs"** statements that fail with:

```
minitest-rails-shoulda/lib/minitest/rails/shoulda/matchers.rb:4:in `require': cannot load such file -- minitest/rails/active_support (LoadError)
```

Fixed by removing the 4 statements and doing a single require "minitest/rails" at the top of the matchers.rb.

**_Note: Sorry I opened an issue first before realising I couldn't attach a pull request to it, which I assumed GitHub would allow.**_

David
