### PR TITLE
Expose Shoulda assertions as MT::Expectations

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,6 +80,61 @@ describe PostsController, "#show" do
 end
 ```
 
+### Shoulda Assertions (Expectations)
+
+Assertions:
+
+```ruby
+# collection contains some value
+assert_contains collection, "a"
+assert_contains collection, /a/
+assert_contains collection, 3
+
+# or
+
+refute_does_not_contain collection, "a"
+refute_does_not_contain collection, /a/
+refute_does_not_contain collection, 3
+
+
+# collection does not contain some value
+refute_contains collection, "b"
+refute_contains collection, /b/
+refute_contains collection, 5
+
+# or
+
+assert_does_not_contain collection, "b"
+assert_does_not_contain collection, /b/
+assert_does_not_contain collection, 5
+
+# collections contain the same elements
+assert_same_elements [1, b, "3"], ["3", 1, b]
+
+# collection does not contain the same elements
+refute_same_elements [1, b, "3"], ["4", b, 1]
+```
+
+And as Expectations:
+
+```ruby
+# collection contains some value
+collection.must_contain "a"
+collection.must_contain /a/
+collection.must_contain 3
+
+# collection does not contain some value
+collection.wont_contain "b"
+collection.wont_contain /b/
+collection.wont_contain 5
+
+# collections contain the same elements
+[1, b, "3"].must_have_same_elements ["3", 1, b]
+
+# collection does not contain the same elements
+[1, b, "3"].wont_have_same_elements ["4", b, 1]
+```
+
 
 ## Contributing
 

--- a/lib/minitest/rails/shoulda.rb
+++ b/lib/minitest/rails/shoulda.rb
@@ -1,4 +1,5 @@
 require "minitest/rails/shoulda/version"
 require "minitest/rails/shoulda/assertions"
+require "minitest/rails/shoulda/expectations"
 require "minitest/rails/shoulda/dsl"
 require "minitest/rails/shoulda/matchers"

--- a/lib/minitest/rails/shoulda/expectations.rb
+++ b/lib/minitest/rails/shoulda/expectations.rb
@@ -1,0 +1,42 @@
+module MiniTest
+  module Expectations
+
+    ##
+    # See MiniTest::Assertions#assert_contains
+    #
+    #   collection.must_contain "a"
+    #   collection.must_contain /a/
+    #
+    # :method: must_contain
+
+    infect_an_assertion :assert_contains, :must_contain, :reverse
+
+    ##
+    # See MiniTest::Assertions#assert_does_not_contain
+    #
+    #   collection.wont_contain "b"
+    #   collection.wont_contain /b/
+    #
+    # :method: wont_contain
+
+    infect_an_assertion :assert_does_not_contain, :wont_contain, :reverse
+
+    ##
+    # See MiniTest::Assertions#assert_same_elements
+    #
+    #   collection.must_have_same_elements ["a", b, 1]
+    #
+    # :method: must_have_same_elements
+
+    infect_an_assertion :assert_same_elements, :must_have_same_elements
+
+    ##
+    # See MiniTest::Assertions#refute_same_elements
+    #
+    #   collection.wont_have_same_elements ["b", c, 3]
+    #
+    # :method: wont_have_same_elements
+
+    infect_an_assertion :refute_same_elements, :wont_have_same_elements
+  end
+end

--- a/test/test_expectations.rb
+++ b/test/test_expectations.rb
@@ -1,0 +1,48 @@
+require "minitest/autorun"
+require "minitest/rails/shoulda/dsl"
+require "minitest/rails/shoulda/assertions"
+require "minitest/rails/shoulda/expectations"
+
+describe "Shoulda Style Expectations" do
+
+  context "an array of values" do
+
+    setup do
+      @a = ['abc', 'def', 3]
+    end
+
+    [/b/, 'abc', 3].each do |x|
+      should "contain #{x.inspect}" do
+        proc { @a.wont_contain x }.must_raise(MiniTest::Assertion)
+
+        @a.must_contain x
+      end
+    end
+
+    should "not contain 'wtf'" do
+      proc { @a.must_contain 'wtf' }.must_raise(MiniTest::Assertion)
+
+      @a.wont_contain 'wtf'
+    end
+
+    should "be the same as another array, ordered differently" do
+      @a.must_have_same_elements [3, "def", "abc"]
+
+      proc {
+        @a.must_have_same_elements [3, 3, "def", "abc"]
+      }.must_raise(MiniTest::Assertion)
+
+      @a.wont_have_same_elements [3, 3, "def", "abc"]
+
+      [@a, "abc"].flatten.must_have_same_elements ["abc", 3, "def", "abc"]
+
+      proc {
+        [@a, "abc"].flatten.must_have_same_elements [3, 3, "def", "abc"]
+      }.must_raise(MiniTest::Assertion)
+
+      [@a, "abc"].flatten.wont_have_same_elements [3, 3, "def", "abc"]
+    end
+
+  end
+
+end


### PR DESCRIPTION
The Shoulda assertions were added to this lib way back in 5e3f9e82 - this exposes them as MiniTest expectations.

Adds:
- must_contain
- wont_contain
- must_have_same_elements
- wont_have_same_elements

Updates:
- README.md
