### PR TITLE
Added Rails4 compatibility

### DIFF
--- a/lib/minitest/rails/shoulda/matchers.rb
+++ b/lib/minitest/rails/shoulda/matchers.rb
@@ -1,7 +1,7 @@
 require "minitest/matchers"
 require "minitest/rails"
 
-if defined?(ActiveRecord)
+if defined?(::ActiveRecord)
   require "shoulda/matchers/active_record"
 
   Shoulda::Matchers::ActiveRecord.module_eval do
@@ -12,7 +12,7 @@ if defined?(ActiveRecord)
     end
   end
 
-  class MiniTest::Rails::ActiveSupport::TestCase
+  class ActiveSupport::TestCase
     include Shoulda::Matchers::ActiveRecord
   end
 end
@@ -28,7 +28,7 @@ if defined?(ActiveModel)
     end
   end
 
-  class MiniTest::Rails::ActiveSupport::TestCase
+  class ActiveSupport::TestCase
     include Shoulda::Matchers::ActiveModel
   end
 end
@@ -44,7 +44,8 @@ if defined?(ActionController)
     end
   end
 
-  class MiniTest::Rails::ActionController::TestCase
+
+  class ActionController::TestCase
     include Shoulda::Matchers::ActionController
   end
 end
@@ -60,7 +61,7 @@ if defined?(ActionMailer)
     end
   end
 
-  class MiniTest::Rails::ActionMailer::TestCase
+  class ActionMailer::TestCase
     include Shoulda::Matchers::ActionMailer
   end
 end

--- a/minitest-rails-shoulda.gemspec
+++ b/minitest-rails-shoulda.gemspec
@@ -17,7 +17,9 @@ Gem::Specification.new do |s|
 #  s.executables   = `git ls-files -- bin/*`.split("\n").map{ |f| File.basename(f) }
   s.require_paths = ["lib"]
 
-  s.add_runtime_dependency "minitest-rails",    "~> 0.5.0"
-  s.add_runtime_dependency "minitest-matchers", "~> 1.2.0"
-  s.add_runtime_dependency "shoulda-matchers",  "~> 1.4.1"
+  s.add_runtime_dependency "minitest-rails",    "~> 0.9.0"
+  s.add_runtime_dependency "minitest-matchers", "~> 1.3.0"
+  s.add_runtime_dependency "shoulda-matchers",  "~> 2.0.0"
+  s.add_runtime_dependency "rails",  "~> 4.0.0.beta1"
+  
 end

--- a/test/rails_helper.rb
+++ b/test/rails_helper.rb
@@ -10,18 +10,26 @@ class TestApp < Rails::Application
 end
 class HelloController < ActionController::Base
   def world
-    render inline: "<!DOCTYPE html><title>TestApp</title>
-                    <h1>Hello <span>World</span></h1>
-                    <nav><ul><li><a href='/'>home</a></li></ul></nav>
-                    <p><label>Email Address<input type='text'></label></p>
-                    <button>random button</button>
-                    <label>going<input type='checkbox' checked='checked'></label>
-                    <label>avoid<input type='checkbox'></label>"
+    respond_to do |format|
+      format.html do
+        render inline: "<!DOCTYPE html><title>TestApp</title>
+                        <h1>Hello <span>World</span></h1>
+                        <nav><ul><li><a href='/'>home</a></li></ul></nav>
+                        <p><label>Email Address<input type='text'></label></p>
+                        <button>random button</button>
+                        <label>going<input type='checkbox' checked='checked'></label>
+                        <label>avoid<input type='checkbox'></label>"
+      end
+      format.xml do
+        render inline: 'No!', status: :forbidden
+      end
+    end
   end
 end
 
 Rails.application = TestApp
 
+require 'rails/test_help'
 require "minitest/rails"
 require "minitest/rails/shoulda"
 

--- a/test/test_matchers.rb
+++ b/test/test_matchers.rb
@@ -2,45 +2,63 @@ require "rails_helper"
 
 describe HelloController do
 
-  context "index" do
+  describe "index" do
     setup do
       get :world
     end
 
     describe "assertions" do
       it "should give us HTML" do
-        assert_respond_with_content_type(@controller, :html)
+        get :world, format: :html
+        assert_respond_with(@controller, :success)
+        # @controller.should respond_with_content_type(:html)
+        # assert_respond_with_content_type(@controller, :html)
       end
 
       it "should not give us XML" do
-        refute_respond_with_content_type(@controller, :xml)
+        get :world, format: :xml
+        assert_respond_with(@controller, :forbidden)
+        # refute_respond_with_content_type(@controller, :xml)
       end
     end
 
     describe "with matchers" do
-      should "give us HTML" do
-        @controller.must respond_with_content_type(:html)
+      it "should give us HTML" do
+        must respond_with(:success)
+      end
+      
+      it "should eventually give us JSON" do
+        skip "should_eventually give us JSON"
       end
 
-      should_eventually "give us JSON"
 
       # should_eventually "give us JSON" do
       #   @controller.must respond_with_content_type(:json)
       # end
 
-      should "not give us XML" do
-        @controller.wont respond_with_content_type(:xml)
+      it "should not give us XML" do
+        get :world, format: :xml
+        wont respond_with(:success)
       end
     end
 
     describe "with subject" do
       subject { @controller }
+      
+      describe "Html request" do
+        it { must respond_with(:success) }
+        it { wont respond_with(:forbidden) }
+      end
+      
+      describe "Forbidden XML request" do
+        before :each do
+          get :world, format: :xml
+        end
+        it { must respond_with(:forbidden) }
+        it { wont respond_with(:success) }
+      end
 
-      it { must respond_with_content_type(:html) }
-      it { wont respond_with_content_type(:xml) }
 
-      must { respond_with_content_type(:html) }
-      wont { respond_with_content_type(:xml) }
     end
   end
 


### PR DESCRIPTION
A few things have moved around in recent versions of minitest-rails... see https://github.com/blowmage/minitest-rails/wiki/Upgrading-to-0.9 for details.

Also,

Recent versions of shoulda-matchers (apparently) have removed the
respond_with_content_type matcher.  I only guess so because I can't
find it in the current version.  Therefore I've replaced those tests
with (imho) suitable replacement matchers.

_I doubt_ you'll want to merge this pull request with master... but I wanted to show you this work in case you're ready to add a rails4 branch.
